### PR TITLE
add instructions to disable GSP Firmware for CMP 30/40 cards

### DIFF
--- a/docs/README-LINUX.md
+++ b/docs/README-LINUX.md
@@ -34,6 +34,66 @@ Patching complete.
 cd ~/NVIDIA-Linux-x86_64-xxx.xxx.xx
 sudo ./nvidia-installer
 ```
+### Проблема GSP Firmware 
+Актуально для карт `CMP 30` и `CMP 40`, для повышения производительности и стабильности в игровых и вычислительных 
+нагрузках после успешной установки драйвера необходимо произвести процедуру отключения управления 
+видеокарты через GSP Firmware которая включается автоматически
+
+1. После установки драйвера заблокировать драйвер nouveau:
+```shell
+sudo tee /etc/modprobe.d/blacklist-nouveau.conf >/dev/null <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+```
+2. Отключение GSP Firmware:
+```shell
+sudo tee /etc/modprobe.d/nvidia.conf >/dev/null <<'EOF'
+options nvidia NVreg_EnableGpuFirmware=0
+EOF
+```
+3. GRUB
+В файл `/etc/default/grub` добавить параметр `nvidia.NVreg_EnableGpuFirmware=0`.   
+
+Например:
+```text
+   GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvidia.NVreg_EnableGpuFirmware=0"
+```
+4. Обновить GRUB и initramfs
+```shell
+sudo update-grub && sudo update-initramfs -u -k all
+```
+5. Перезагрузка
+6. Проверка
+```shell
+nvidia-smi -q | grep GSP
+```
+Если GSP отключён — будет GSP Firmware: N/A или отсутствовать.
+
+  
+⚠️ Important
+
+Linux имеет множество дистрибутивов с разными пакетными менеджерами,  
+механизмами initramfs, настройками GRUB и системными утилитами.  
+
+Данная инструкция является универсальной и описывает общий проверенный подход.  
+Она не может учитывать все особенности каждого конкретного дистрибутива.  
+
+В отдельных случаях команды могут отличаться и требуют адаптации  
+согласно документации вашего дистрибутива.  
+
+Для корректной работы скрипта в системе должны быть установлены следующие утилиты:  
+
+- bash
+- coreutils
+- grep
+- sed
+- xxd
+
+Как правило, они уже присутствуют в базовой установке большинства дистрибутивов Linux,  
+но в минимальных системах могут потребовать установки вручную.  
+
+Как аналог MSI Afterburner в Linux можно использовать [LACT](https://github.com/ilya-zlobintsev/LACT)
 
 
  # Linux Instruction
@@ -71,3 +131,64 @@ Patching complete.
 cd ~/NVIDIA-Linux-x86_64-xxx.xxx.xx
 sudo ./nvidia-installer
 ```
+
+### GSP Firmware Issue
+Applicable to CMP 30 and CMP 40 GPUs.  
+To improve performance and stability in gaming and compute workloads, after a successful driver installation it is   
+recommended to disable GPU control via GSP Firmware, which is enabled automatically by default.
+
+1. Blacklist the nouveau driver:
+```shell
+sudo tee /etc/modprobe.d/blacklist-nouveau.conf >/dev/null <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+```
+2. Disable GSP Firmware:
+```shell
+sudo tee /etc/modprobe.d/nvidia.conf >/dev/null <<'EOF'
+options nvidia NVreg_EnableGpuFirmware=0
+EOF
+```
+3. GRUB configuration  
+Add the parameter `nvidia.NVreg_EnableGpuFirmware=0` to the file `/etc/default/grub`.
+
+Example:
+```text
+   GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nvidia.NVreg_EnableGpuFirmware=0"
+```
+4. Update GRUB and initramfs:
+```shell
+sudo update-grub && sudo update-initramfs -u -k all
+```
+5. Reboot the system.
+6. Verification:
+```shell
+nvidia-smi -q | grep GSP
+```
+If GSP is disabled, the output will show GSP Firmware: N/A or the GSP field will be absent entirely.
+
+
+⚠️ Important
+
+Linux has many different distributions with varying package managers,  
+initramfs implementations, GRUB configurations, and system utilities.  
+
+This guide is intentionally generic and describes a common, proven approach.  
+It cannot account for all distribution-specific details.  
+
+In some cases, commands may differ and require adjustment  
+according to your distribution’s documentation.  
+
+The following utilities are required for the script to work correctly:  
+
+- bash
+- coreutils
+- grep
+- sed
+- xxd
+
+These tools are usually present in most standard Linux installations,  
+but minimal setups may require manual installation.  
+
+As an alternative to MSI Afterburner on Linux, you can use [LACT](https://github.com/ilya-zlobintsev/LACT)


### PR DESCRIPTION
[Issue #433](https://github.com/dartraiden/NVIDIA-patcher/issues/433#issue-3772285143)

Добавлен раздел о GSP Firmware для карт CMP 30/40 в инструкцию по установке драйвера NVIDIA на Linux.

- Пошагово описан способ отключения управления видеокартой через GSP Firmware.
- Добавлены команды для блокировки nouveau, изменения конфигурации модуля NVIDIA и обновления GRUB/initramfs.
- Добавлен блок Important